### PR TITLE
Removing Google Plus link, no longer works

### DIFF
--- a/src/app/templates/about.tpl
+++ b/src/app/templates/about.tpl
@@ -27,7 +27,6 @@
             <a href="<%= Settings.projectUrl %>" data-toggle="tooltip" data-placement="top" title="<%= Settings.projectUrl %>" class='links site_icon'></span></a>
             <a href='http://twitter.com/<%= Settings.projectTwitter %>' data-toggle="tooltip" data-placement="top" title="twitter.com/<%= Settings.projectTwitter %>" class='links twitter_icon'></span></a>
             <a href='http://www.fb.com/<%= Settings.projectFacebook %>' data-toggle="tooltip" data-placement="top" title="fb.com/<%= Settings.projectFacebook %>" class='links facebook_icon'></span></a>
-            <a href='http://plus.google.com/+<%= Settings.projectGooglePlus %>/posts' data-toggle="tooltip" data-placement="top" title="plus.google.com/+<%= Settings.projectGooglePlus %>" class='links google_icon'></span></a>
             <a href='<%= Settings.projectUrl %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectUrl %>" class='links gitlab_icon'></span></a>
             <a href='<%= Settings.projectBlog %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectBlog %>" class='links blog_icon'></span></a>
             <a href='<%= Settings.projectForum %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectForum %>" class='links forum_icon'></span></a>


### PR DESCRIPTION
Google plus link no longer works, I'm suggesting that it should be removed from the about page.